### PR TITLE
Add progress bar to `Dendron: Show Note Graph`

### DIFF
--- a/src/dendron/ShowNotesCommand.ts
+++ b/src/dendron/ShowNotesCommand.ts
@@ -65,7 +65,20 @@ export class ShowNotesCommand extends ShowNodeCommand {
     const graph = { nodes: [], edges: [] };
     const nodes = this.getNodes(engine);
     this.parseGraph(nodes, engine, graph);
-    maybePanel.webview.html = await getWebviewContent(context, maybePanel);
+    maybePanel.webview.html = await (
+      opts?.sync ? getWebviewContent(
+        context, maybePanel
+      ) : vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Loading...",
+          cancellable: false,
+        },
+        () => {
+          return getWebviewContent(context, maybePanel);
+        }
+      )
+    );
     if (!cleanOpts.silent) {
       sendGraph(maybePanel, graph);
     }


### PR DESCRIPTION
This PR:
- Adds a progress bar to `Dendron: Show Note Graph`

closes: https://github.com/dendronhq/dendron/issues/456